### PR TITLE
Handle nodata values and masks in `read_geotif`

### DIFF
--- a/plantcv/geospatial/read_geotif.py
+++ b/plantcv/geospatial/read_geotif.py
@@ -50,7 +50,7 @@ def _parse_bands(bands):
     band_strs = bands.split(",")
 
     # Default values for symbolic bands
-    default_wavelengths = {"R": 650, "G": 560, "B": 480, "RE": 717, "N": 842, "NIR": 842}
+    default_wavelengths = {"R": 650, "G": 560, "B": 480, "RE": 717, "N": 842, "NIR": 842, "MASK":0}
 
     for band in band_strs:
         # Check if the band symbols are supported

--- a/plantcv/geospatial/read_geotif.py
+++ b/plantcv/geospatial/read_geotif.py
@@ -121,6 +121,14 @@ def read_geotif(filename, bands="R,G,B", cropto=None):
 
     # Make a list of wavelength keys
     wl_keys = wavelengths.keys()
+    if 0 in wl_keys:
+        id_mask = _find_closest_unsorted(array=np.array([float(i) for i in wl_keys]), target=0)
+        mask_layer = img_data[:, :, [id_mask]]
+        if len(np.unique(mask_layer)) > 2:
+            fatal_error(f"your specified mask is not binary")
+        else:
+            # apply mask
+            # img_data[mask_layer == 0] = 0
     # Find which bands to use for red, green, and blue bands of the pseudo_rgb image
     id_red = _find_closest_unsorted(array=np.array([float(i) for i in wl_keys]), target=630)
     id_green = _find_closest_unsorted(array=np.array([float(i) for i in wl_keys]), target=540)


### PR DESCRIPTION
**Describe your changes**
Add detection and check for mask layer within geotifs by adding it as a supported "wavelength" with a label of "0nm". 

**Type of update**
Is this a:
*  feature enhancement
* Work in progress

**Associated issues**
Reference associated issue numbers. Does this pull request close any issues?

**Additional context**
Add any other context about the problem here.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
