### PR TITLE
Fix transform points

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for
 - [ ] All tests pass
 - [ ] Test coverage remains 100%
 - [ ] Documentation tested
-- [ ] New documentation pages added to `plantcv/mkdocs.yml`
-- [ ] Changes to function input/output signatures added to `updating.md`
+- [ ] New documentation pages added to `plantcv-geospatial/mkdocs.yml`
+- [ ] Changes to function input/output signatures added to `changelog.md`
 - [ ] Code reviewed
 - [ ] PR approved

--- a/plantcv/geospatial/read_geotif.py
+++ b/plantcv/geospatial/read_geotif.py
@@ -90,8 +90,9 @@ def _read_geotif_and_shapefile(filename, cropto):
                 shapes = [mapping(convex_hull)]
         # rasterio does the cropping within open
         with rasterio.open(filename, 'r') as src:
-            img_data, _ = mask(src, shapes, crop=True)
+            img_data, trans_metadata = mask(src, shapes, crop=True)
             metadata = src.meta.copy()
+            metadata.update({"transform": trans_metadata})
             d_type = src.dtypes[0]
 
     else:

--- a/plantcv/geospatial/transform_points.py
+++ b/plantcv/geospatial/transform_points.py
@@ -19,11 +19,11 @@ def transform_points(img, geojson):
 
     coord = []
     with fiona.open(geojson, 'r') as shapefile:
-        for i, _ in enumerate(shapefile):
-            if type((shapefile[i].geometry["coordinates"])) is list:
-                pixel_point = ~(geo_transform) * (shapefile[i].geometry["coordinates"][0])
-            if type((shapefile[i].geometry["coordinates"])) is tuple:
-                pixel_point = ~(geo_transform) * (shapefile[i].geometry["coordinates"])
+        for row in shapefile:
+            if type((row.geometry["coordinates"])) is list:
+                pixel_point = ~(geo_transform) * (row.geometry["coordinates"][0])
+            if type((row.geometry["coordinates"])) is tuple:
+                pixel_point = ~(geo_transform) * (row.geometry["coordinates"])
             rounded = (int(pixel_point[0]), int(pixel_point[1]))
             coord.append(rounded)
 


### PR DESCRIPTION
**Describe your changes**
After transform.points was merged, it was discovered that for long geojson files, `enumerate` behaves incorrectly and only some of the file lines get read. This PR changes the logic to fix this problem. 

**Type of update**
Is this a:
* Bug fix


**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [ ] PR approved
