### PR TITLE
Add plot ids to debug images we create

### DIFF
--- a/plantcv/geospatial/_helpers.py
+++ b/plantcv/geospatial/_helpers.py
@@ -146,7 +146,7 @@ def _calc_plot_corners(anchor_point, horizontal_dir, vertical_dir, col_num,
     return p1, p2, p3, p4
 
 
-def _show_geojson(img, geojson):
+def _show_geojson(img, geojson, ids):
     """Split a polygon into equidistant subplots
 
     Parameters:
@@ -155,6 +155,8 @@ def _show_geojson(img, geojson):
         Spectral_Data object of geotif data, used for plotting
     geojson : str
         Path to the shape file containing the regions
+    ids : list
+        List of plot IDs from _gather_ids
 
     Returns:
     --------
@@ -173,12 +175,15 @@ def _show_geojson(img, geojson):
     fig_extent = plotting_extent(img.array_data[:, :, :3],
                                  img.metadata['transform'])
     # Add labels to vector features
-    for idx, row in geojson.iterrows():
-        plt.text(row.geometry.centroid.x, row.geometry.centroid.y, row['ID_COLUMN'], fontsize=8)
+    for idx, row in bounds.iterrows():
+        plt.text(row.geometry.centroid.x,
+                 row.geometry.centroid.y,
+                 ids[idx], fontsize=5,
+                 c="m")
 
     ax.imshow(flipped, extent=fig_extent)
     # Plot the shapefile
-    bounds.boundary.plot(ax=ax, color="red")
+    bounds.boundary.plot(ax=ax, color="blue")
     # Set plot title and labels
     plt.title("GeoJSON shapes on GeoTIFF")
     # Store the plot

--- a/plantcv/geospatial/_helpers.py
+++ b/plantcv/geospatial/_helpers.py
@@ -172,6 +172,10 @@ def _show_geojson(img, geojson):
     _, ax = plt.subplots(figsize=(10, 10))
     fig_extent = plotting_extent(img.array_data[:, :, :3],
                                  img.metadata['transform'])
+    # Add labels to vector features
+    for idx, row in geojson.iterrows():
+        plt.text(row.geometry.centroid.x, row.geometry.centroid.y, row['ID_COLUMN'], fontsize=8)
+
     ax.imshow(flipped, extent=fig_extent)
     # Plot the shapefile
     bounds.boundary.plot(ax=ax, color="red")
@@ -214,7 +218,9 @@ def _gather_ids(geojson):
         # If IDs within the geojson
         ids = []
         for i, row in enumerate(shapefile):
-            if 'ID' in row['properties']:
+            if 'PlotName' in row['properties']:
+                ids.append((row['properties']["PlotName"]))
+            elif 'ID' in row['properties']:
                 ids.append((row['properties']["ID"]))
             elif 'FID' in row['properties']:
                 ids.append((row['properties']["FID"]))

--- a/plantcv/geospatial/analyze/coverage.py
+++ b/plantcv/geospatial/analyze/coverage.py
@@ -1,5 +1,5 @@
 # Analyze pixel count over many regions
-from plantcv.geospatial._helpers import _gather_ids
+from plantcv.geospatial._helpers import _gather_ids, _show_geojson
 from plantcv.plantcv import outputs, params
 from rasterio.plot import plotting_extent
 from rasterstats import zonal_stats
@@ -68,30 +68,8 @@ def coverage(img, bin_mask, geojson):
     outputs.add_metadata(term="ground_sampling_distance_x", datatype=float, value=gsd_x)
     outputs.add_metadata(term="ground_sampling_distance_y", datatype=float, value=gsd_y)
 
-    bounds = geopandas.read_file(geojson)
-
     # Plot the GeoTIFF
-    # Make a flipped image for graphing
-    flipped = cv2.merge((img.pseudo_rgb[:, :, [2]],
-                         img.pseudo_rgb[:, :, [1]],
-                         img.pseudo_rgb[:, :, [0]]))
-
-    _, ax = plt.subplots(figsize=(10, 10))
-    fig_extent = plotting_extent(img.array_data[:, :, :3],
-                                 img.metadata['transform'])
-    ax.imshow(flipped, extent=fig_extent)
-    # Plot the shapefile
-    bounds.boundary.plot(ax=ax, color="red")
-    # Add labels to vector features
-    for idx, row in bounds.iterrows():
-        plt.text(row.geometry.centroid.x,
-                 row.geometry.centroid.y,
-                 ids[idx], fontsize=5,
-                 c="m")
-    # Set plot title and labels
-    plt.title("Shapefile on GeoTIFF")
-    # Store the plot
-    plotting_img = plt.gcf()
+    plotting_img = _show_geojson(img, geojson, ids=ids)
 
     # Print or plot if debug is turned on
     if params.debug is not None:

--- a/plantcv/geospatial/analyze/coverage.py
+++ b/plantcv/geospatial/analyze/coverage.py
@@ -82,6 +82,12 @@ def coverage(img, bin_mask, geojson):
     ax.imshow(flipped, extent=fig_extent)
     # Plot the shapefile
     bounds.boundary.plot(ax=ax, color="red")
+    # Add labels to vector features
+    for idx, row in bounds.iterrows():
+        plt.text(row.geometry.centroid.x,
+                 row.geometry.centroid.y,
+                 ids[idx], fontsize=5,
+                 c="m")
     # Set plot title and labels
     plt.title("Shapefile on GeoTIFF")
     # Store the plot


### PR DESCRIPTION
**Describe your changes**
Add plot labels, which are detected from a given geojson or are numerated with the analysis `label` parameter as a base name. Also change the plot boundary lines to be blue, rather than red, since it's more colorblind friendly. 

**Type of update**
Is this a:
* feature enhancement
* Work in progress

**Associated issues**
Reference associated issue numbers. Does this pull request close any issues?

**Additional context**
Add any other context about the problem here.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv-geospatial/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `changelog.md`
- [ ] Code reviewed
- [ ] PR approved
