### PR TITLE
Handle float32

### DIFF
--- a/plantcv/geospatial/images.py
+++ b/plantcv/geospatial/images.py
@@ -84,6 +84,7 @@ class GEO(Image):
         thumb = np.dstack([self.get_wavelength(self.default_wavelengths[0]),
                            self.get_wavelength(self.default_wavelengths[1]),
                            self.get_wavelength(self.default_wavelengths[2])])
+        thumb[thumb == self.nodata] = 0
         return thumb
 
 

--- a/plantcv/geospatial/images.py
+++ b/plantcv/geospatial/images.py
@@ -108,7 +108,7 @@ class DSM(Image):
         super().__init__()
         self.data_array = self._gray_cutoff()
         self.thumb = self._create_thumb()
-        self.nodata = 0
+        #self.nodata = 0
 
     def __array_finalize__(self, obj):
         super().__array_finalize__(obj)

--- a/plantcv/geospatial/images.py
+++ b/plantcv/geospatial/images.py
@@ -46,6 +46,7 @@ class GEO(Image):
                  default_wavelengths: list, crs: str, transform: affine.Affine, nodata: float):
         super().__init__()
         self.thumb = self._create_thumb()
+        self.nodata = 0
 
     def __array_finalize__(self, obj):
         super().__array_finalize__(obj)
@@ -107,6 +108,7 @@ class DSM(Image):
         super().__init__()
         self.data_array = self._gray_cutoff()
         self.thumb = self._create_thumb()
+        self.nodata = 0
 
     def __array_finalize__(self, obj):
         super().__array_finalize__(obj)

--- a/plantcv/geospatial/images.py
+++ b/plantcv/geospatial/images.py
@@ -127,7 +127,7 @@ class DSM(Image):
         img_copy = np.squeeze(self)
         if self.cutoff is not None :
             quantile = np.quantile(img_copy, self.cutoff)
-            img_copy[img_copy >= quantile] = np.nan
+            img_copy[img_copy >= quantile] = 0
         return img_copy
 
     def _create_thumb(self):
@@ -138,7 +138,7 @@ class DSM(Image):
         numpy.ndarray
             Stretched thumbnail
         """
-        img_copy = self.data_array
+        img_copy = self.data_array.astype(np.float64)
         # Change nodata values to Nan
         img_copy[img_copy == self.nodata] = np.nan
         # Stretch values to min/max for visualization

--- a/plantcv/geospatial/read/geotif.py
+++ b/plantcv/geospatial/read/geotif.py
@@ -66,6 +66,8 @@ def _read_geotif_and_shapefile(filename, cropto):
     -------
     img_data : numpy.ndarray
         Image data array with shape ``(bands, height, width)``.
+    nodata_indicies : numpy.ndarray
+        Coordinates of missing data that has been replaced with 0s.
     metadata : dict
         Rasterio metadata dictionary including CRS, transform, and driver
         information.
@@ -152,18 +154,16 @@ def geotif(filename, bands="R,G,B", cropto=None, cutoff=None):
 
     # Check if img is uint16
     if img_data.dtype == "uint16":
-        img_copy = np.where(img_data == metadata["nodata"], 0, img_data)
-        img_copy = ((img_copy/65535.0) * 255.0).astype(np.uint8)
-        img_data = np.where(img_data == metadata["nodata"], metadata["nodata"], img_copy)
-    
+        img_data = np.where(img_data == metadata["nodata"], 0, img_data)
+        img_data = ((img_data/65535.0) * 255.0).astype(np.uint8)
+
     # Check if img is float32
     if img_data.dtype == "float32":
         # Replace nodata with 0
-        img_copy = np.where(img_data == metadata["nodata"], 0, img_data)
-        img_copy = img_copy ** (1 / 2.2)
-        img_copy = (img_copy * 255).astype("uint8")
-        img_data = np.where(img_data == metadata["nodata"], metadata["nodata"], img_copy)
-    
+        img_data = np.where(img_data == metadata["nodata"], 0, img_data)
+        img_data = img_data ** (1 / 2.2)
+        img_data = (img_data * 255).astype("uint8")
+
     if depth > 1:
         # Make a GEO instance before calculating a pseudo-rgb
         obj = GEO(input_array=img_data,

--- a/plantcv/geospatial/read/geotif.py
+++ b/plantcv/geospatial/read/geotif.py
@@ -152,7 +152,18 @@ def geotif(filename, bands="R,G,B", cropto=None, cutoff=None):
 
     # Check if img is uint16
     if img_data.dtype == "uint16":
-        img_data = ((img_data/65535.0) * 255.0).astype(np.uint8)
+        img_copy = np.where(img_data == metadata["nodata"], 0, img_data)
+        img_copy = ((img_copy/65535.0) * 255.0).astype(np.uint8)
+        img_data = np.where(img_data == metadata["nodata"], metadata["nodata"], img_copy)
+    
+    # Check if img is float32
+    if img_data.dtype == "float32":
+        # Replace nodata with 0
+        img_copy = np.where(img_data == metadata["nodata"], 0, img_data)
+        img_copy = img_copy ** (1 / 2.2)
+        img_copy = (img_copy * 255).astype("uint8")
+        img_data = np.where(img_data == metadata["nodata"], metadata["nodata"], img_copy)
+    
     if depth > 1:
         # Make a GEO instance before calculating a pseudo-rgb
         obj = GEO(input_array=img_data,


### PR DESCRIPTION
**Describe your changes**
Adding logic to handle float32 dtype images. Changes how nodata values are handled when reading in data.

**Type of update**
This is a bug fix.

**Associated issues**
None

**Additional context**
This does not yet apply the changes to analyze functions where the nodata value is used, we are expecting to handle that at some other time with a mask passed to zonal_stats.

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv-geospatial/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `changelog.md`
- [ ] Code reviewed
- [ ] PR approved
