### PR TITLE
updated img.thumb to correct channel order

### DIFF
--- a/plantcv/geospatial/create_shapes/interactive_shapes.py
+++ b/plantcv/geospatial/create_shapes/interactive_shapes.py
@@ -32,7 +32,7 @@ class InteractiveShapes:
 
         self.img = img
         self.layer_dict = {}
-        self.viewer.add_image(img.thumb)
+        self.viewer.add_image(img.thumb[..., ::-1])
         self.viewer.add_shapes(name=field_layer)
         self.layer_dict["field_boundary"] = field_layer
 

--- a/plantcv/geospatial/create_shapes/interactive_shapes.py
+++ b/plantcv/geospatial/create_shapes/interactive_shapes.py
@@ -31,8 +31,9 @@ class InteractiveShapes:
             fatal_error("Only napari viewers are currently supported.")
 
         self.img = img
+        self.thumb = img.thumb[..., ::-1]
         self.layer_dict = {}
-        self.viewer.add_image(self.img.thumb)
+        self.viewer.add_image(self.thumb)
         self.viewer.add_shapes(name=field_layer)
         self.layer_dict["field_boundary"] = field_layer
 

--- a/plantcv/geospatial/create_shapes/interactive_shapes.py
+++ b/plantcv/geospatial/create_shapes/interactive_shapes.py
@@ -32,7 +32,7 @@ class InteractiveShapes:
 
         self.img = img
         self.layer_dict = {}
-        self.viewer.add_image(img.thumb[..., ::-1])
+        self.viewer.add_image(self.img.thumb)
         self.viewer.add_shapes(name=field_layer)
         self.layer_dict["field_boundary"] = field_layer
 


### PR DESCRIPTION
**Describe your changes**
img.thumb opened in the wrong channel order, modified it so it corrects the channel order.

**Type of update**
Is this a:
* Bug fix

**Associated issues**
Issue #113 part 1

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv-geospatial/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `changelog.md`
- [x] Code reviewed
- [x] PR approved
