### PR TITLE
Dsm thumbnails

### DIFF
--- a/docs/image_classes.md
+++ b/docs/image_classes.md
@@ -54,7 +54,7 @@ Attributes are accessed as DSM.*attribute*.
 
 - **cutoff**: A cutoff for how high a pixel can be, pixels above this height will be converted to `numpy.nan`.
 
-- **thumb**: A thumbnail image in 3 channels defined by `default_wavelengths`. Similar to a psuedo-rgb image from the `plantcv.plantcv.Spectral_data` class.
+- **thumb**: A grayscale thumbnail image of the DSM.
 
 
 **Source Code:** [Here](https://github.com/danforthcenter/plantcv-geospatial/blob/main/plantcv/geospatial/images.py)

--- a/plantcv/geospatial/images.py
+++ b/plantcv/geospatial/images.py
@@ -138,13 +138,19 @@ class DSM(Image):
         numpy.ndarray
             Stretched thumbnail
         """
-        img_copy = self.data_array
-        # Change nodata values to Nan
-        img_copy[img_copy == self.nodata] = np.nan
-        # Stretch values to min/max for visualization
-        img_copy = 255*((img_copy - np.nanmin(img_copy)) / (np.nanmax(img_copy) - np.nanmin(img_copy)))
-        # Return nodata values to 0
-        img_copy = np.nan_to_num(img_copy, nan=0.0)
+        img_data = self.data_array
+        # make masked array for nodata values
+        mask = np.where(img_data == self.nodata, 1, 0)
+        mx = np.ma.masked_array(img_data, mask)
+        # get range of masked array for visualization
+        mxmin = mx.min()
+        mxmax = mx.max()
+        # make copy of image squashed into uint8 range
+        img_copy = 255 * ((mx - mxmin) / (mxmax - mxmin))
         # Convert to uint8
         thumb = img_copy.astype(np.uint8)
+        # remove data from masked array
+        thumb = thumb.data
+        # slice 0s in for no-data
+        thumb = np.where(mask == 1, 0, thumb)
         return thumb

--- a/plantcv/geospatial/read/geotif.py
+++ b/plantcv/geospatial/read/geotif.py
@@ -121,6 +121,11 @@ def geotif(filename, bands="R,G,B", cropto=None, cutoff=None):
     # reshape such that z-dimension is last
     img_data = img_data.transpose(1, 2, 0)
     _, _, depth = img_data.shape
+    # Parse bands
+    bands = _parse_bands(bands)
+    if (depth == 1 and len(bands) > 1):
+        warn(f"Bands specified as {bands} but data has 1 channel, bands have been reset to GRAY for a DSM.")
+        bands = [0]
     # Check for mask
     mask_layer = None
     mask_band_indices = []
@@ -132,8 +137,6 @@ def geotif(filename, bands="R,G,B", cropto=None, cutoff=None):
         img_data = np.delete(img_data, mask_band_indices, 2)
     # reset depth in case the image data was changed
     _, _, depth = img_data.shape
-    # Parse bands
-    bands = _parse_bands(bands)
     # Check if user input matches image dimension in z direction
     if depth > len(bands):
         warn(f"{depth} bands found in the image data but {filename} was provided with {bands}. " +

--- a/tests/read/test_geospatial_read_geotif.py
+++ b/tests/read/test_geospatial_read_geotif.py
@@ -77,3 +77,11 @@ def test_geospatial_read_geotif_gray(test_data):
     img = geotif(filename=test_data.gray_tif, bands="gray", cutoff=0.99)
     assert img.shape[0] == 411
     assert isinstance(img, DSM)
+
+
+def test_geospatial_read_geotif_gray_wrong_bands(test_data):
+    """Test for plantcv-geospatial."""
+    # read in small gray image
+    img = geotif(filename=test_data.gray_tif, cutoff=0.99)
+    assert img.shape[0] == 411
+    assert isinstance(img, DSM)


### PR DESCRIPTION
**Describe your changes**
Applies logic from @k034b363 to make DSM thumbnails without modifying the original array and adds logic to correct bands if default arguments are used to read in a DSM from `gsm.read.geotif`

**Type of update**
This is a bug fix.

**Associated issues**
Closes #128 

**Additional context**
None

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv-geospatial/mkdocs.yml`
- [x] Changes to function input/output signatures added to `changelog.md`
- [x] Code reviewed
- [ ] PR approved
