### PR TITLE
Use params.text_size in _show_geojson

### DIFF
--- a/plantcv/geospatial/_helpers.py
+++ b/plantcv/geospatial/_helpers.py
@@ -223,7 +223,7 @@ def _show_geojson(img, geojson, ids, **kwargs):
         for idx, row in bounds.iterrows():
             x_coord = (row.geometry.bounds[0] + row.geometry.centroid.x) / 2
             y_coord = row.geometry.centroid.y
-            plt.text(x_coord, y_coord, ids[idx], fontsize=10, c="m")
+            plt.text(x_coord, y_coord, ids[idx], fontsize=params.text_size, c="m")
 
     ax.imshow(flipped, extent=fig_extent, **kwargs)
     # Plot the shapefile


### PR DESCRIPTION
**Describe your changes**
The helper function `_show_geojson` uses a hard-coded text size for displaying plot labels on debugs. This PR updates it to pull PlantCV's params.text_size instead.

**Type of update**
* New feature or feature enhancement


**Associated issues**
Closes #130 


**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv-geospatial/mkdocs.yml`
- [x] Changes to function input/output signatures added to `changelog.md`
- [x] Code reviewed
- [x] PR approved
