### PR TITLE
Change band order of thumbnail

### DIFF
--- a/plantcv/geospatial/read/geotif.py
+++ b/plantcv/geospatial/read/geotif.py
@@ -161,7 +161,7 @@ def geotif(filename, bands="R,G,B", cropto=None, cutoff=None):
         obj = GEO(input_array=img_data,
                   filename=filename,
                   wavelengths=bands,
-                  default_wavelengths=[650, 560, 480],
+                  default_wavelengths=[480, 560, 650],
                   crs=metadata["crs"],
                   transform=metadata["transform"],
                   nodata=metadata["nodata"]


### PR DESCRIPTION
**Describe your changes**
The thumbnail image was previously being stored as RGB, but to be consistent with main PlantCV, this PR changes the thumbnail to BGR. 

**Type of update**
Is this a:
* Bug fix

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv-geospatial/mkdocs.yml`
- [x] Changes to function input/output signatures added to `changelog.md`
- [x] Code reviewed
- [x] PR approved
