### PR TITLE
Update spectral to behave differently for new spectral indices

### DIFF
--- a/plantcv/geospatial/analyze/spectral.py
+++ b/plantcv/geospatial/analyze/spectral.py
@@ -40,12 +40,12 @@ def _convert_spectral(img, index, distance):
 
     # Calculate index using pcv.spectral_index
     chosen = getattr(pcv_spectral, index)
-    
+
     # Check first to see if index is one that requires different inputs
     diff_inds = ["sci", "bgr", "bgi"]
     if index in diff_inds:
         return chosen(img.thumb)
-        
+
     return chosen(spectral_input, distance=distance)
 
 

--- a/plantcv/geospatial/analyze/spectral.py
+++ b/plantcv/geospatial/analyze/spectral.py
@@ -40,6 +40,12 @@ def _convert_spectral(img, index, distance):
 
     # Calculate index using pcv.spectral_index
     chosen = getattr(pcv_spectral, index)
+    
+    # Check first to see if index is one that requires different inputs
+    diff_inds = ["sci", "bgr", "bgi"]
+    if index in diff_inds:
+        return chosen(img.thumb)
+        
     return chosen(spectral_input, distance=distance)
 
 

--- a/tests/analyze/test_geospatial_analyze_spectral_index.py
+++ b/tests/analyze/test_geospatial_analyze_spectral_index.py
@@ -8,7 +8,7 @@ from plantcv.geospatial.analyze import spectral_index as analyze_spectral
 
 @pytest.mark.parametrize("debug,percentiles,index", [["print", None, "evi"],
                                                ["plot", None, "evi"],
-                                               [None, [33, 75, 92], "egi"]])
+                                               [None, [33, 75, 92], "sci"]])
 def test_analyze_spectral_index(debug, tmpdir, test_data, percentiles, index):
     """Test for PlantCV."""
     # Clear previous outputs


### PR DESCRIPTION
**Describe your changes**
New spectral indices `sci`, `bgr`, and `bgi` take different inputs than others and were giving an error when trying to use `geospatial.analyse.spectral_index` to calculate. This PR adds a different behavior when the user requests one of those indices for analysis. 

**Type of update**
* Bug fix

**Associated issues**
Closes #133 

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv-geospatial/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `changelog.md`
- [ ] Code reviewed
- [ ] PR approved
