### PR TITLE
Fix DSM squeeze bug in resize

### DIFF
--- a/plantcv/geospatial/resize.py
+++ b/plantcv/geospatial/resize.py
@@ -100,6 +100,8 @@ def _resize_array(arr, size, interpolation):
         return np.dstack([cv2.resize(arr[:, :, i], dsize=size, interpolation=interp_mtd)
                           for i in range(arr.shape[2])])
     resized = pcv_resize(arr, size=size, interpolation=interpolation)
+    if arr.shape[2] > 1:
+        return resized
     # Add empty third dimension back to match read in DSMs
     return np.expand_dims(resized, axis=-1)
 

--- a/plantcv/geospatial/resize.py
+++ b/plantcv/geospatial/resize.py
@@ -99,7 +99,9 @@ def _resize_array(arr, size, interpolation):
         interp_mtd = _set_interpolation(input_size=arr.shape[:2], output_size=size, method=interpolation)
         return np.dstack([cv2.resize(arr[:, :, i], dsize=size, interpolation=interp_mtd)
                           for i in range(arr.shape[2])])
-    return pcv_resize(arr, size=size, interpolation=interpolation)
+    resized = pcv_resize(arr, size=size, interpolation=interpolation)
+    # Add empty third dimension back to match read in DSMs
+    return np.expand_dims(resized, axis=-1)
 
 
 def _scale_transform(transform, orig_w, orig_h, new_w, new_h):


### PR DESCRIPTION
**Describe your changes**
Geospatial's resize function wraps main PlantCV, which returns a squeezed version of resized grayscales. This means that the dimensions of resized DSMs do not match un-resized DSMs, which have an empty third dimension when read in. This PR fixes that by adding the empty dimension back.

**Type of update**
* Bug fix

**Associated issues**
Closes #140 

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv-geospatial/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `changelog.md`
- [ ] Code reviewed
- [ ] PR approved
