### PR TITLE
change default wavelengths to 670 for red channel

### DIFF
--- a/docs/read_geotif.md
+++ b/docs/read_geotif.md
@@ -8,9 +8,9 @@ Read in data from a GeoTIFF file (e.g., georeferenced aerial or multispectral im
 
 - **Parameters:**
     - filename - Path of the TIF image file.
-    - bands - A comma-separated string of band labels (e.g., "R,G,B") or a list of wavelengths in nm (e.g., [650, 560, 480]). Default is "R,G,B".
+    - bands - A comma-separated string of band labels (e.g., "R,G,B") or a list of wavelengths in nm (e.g., [670, 560, 480]). Default is "R,G,B".
         - Supported symbols (case insensitive) and their default wavelengths: 
-            - "R" (red) = 650nm
+            - "R" (red) = 670nm
             - "G" (green) = 560nm
             - "B" (blue) = 480nm
             - "RE" (rededge) = 717nm

--- a/plantcv/geospatial/read/geotif.py
+++ b/plantcv/geospatial/read/geotif.py
@@ -19,7 +19,7 @@ def _parse_bands(bands):
     bands : str or list
         Comma-separated string of band symbols (e.g., ``"R,G,B"``) or a list
         of wavelengths.
-        Currently Supported Band Symbols: R (650 nm), G (560 nm), B (480 nm),
+        Currently Supported Band Symbols: R (670 nm), G (560 nm), B (480 nm),
         RE (717 nm), N (842 nm), NIR (842 nm), GRAY (0).
 
     Returns
@@ -36,7 +36,7 @@ def _parse_bands(bands):
     band_strs = bands.split(",")
 
     # Default values for symbolic bands
-    default_wavelengths = {"R": 650, "G": 560, "B": 480, "RE": 717, "N": 842,
+    default_wavelengths = {"R": 670, "G": 560, "B": 480, "RE": 717, "N": 842,
                            "NIR": 842, "GRAY": 0}
 
     for band in band_strs:
@@ -161,7 +161,7 @@ def geotif(filename, bands="R,G,B", cropto=None, cutoff=None):
         obj = GEO(input_array=img_data,
                   filename=filename,
                   wavelengths=bands,
-                  default_wavelengths=[480, 560, 650],
+                  default_wavelengths=[480, 560, 670],
                   crs=metadata["crs"],
                   transform=metadata["transform"],
                   nodata=metadata["nodata"]

--- a/plantcv/geospatial/read/netcdf.py
+++ b/plantcv/geospatial/read/netcdf.py
@@ -144,7 +144,7 @@ def netcdf(filename, cropto, output=False):
                                                 np.max(lat), lat.shape[1], lat.shape[0])
 
     # Make the pseudo_rgb
-    id_red = _find_closest_unsorted(array=np.array([float(i) for i in wavelengths]), target=630)
+    id_red = _find_closest_unsorted(array=np.array([float(i) for i in wavelengths]), target=670)
     id_green = _find_closest_unsorted(array=np.array([float(i) for i in wavelengths]), target=540)
     id_blue = _find_closest_unsorted(array=np.array([float(i) for i in wavelengths]), target=480)
     # Stack bands together, BGR since plot_image will convert BGR2RGB automatically
@@ -174,7 +174,7 @@ def netcdf(filename, cropto, output=False):
                                    lines=int(height), interleave=None,
                                    wavelength_units="nm", array_type="datacube",
                                    pseudo_rgb=pseudo_rgb, filename=filename,
-                                   default_bands=[480, 540, 630],
+                                   default_bands=[480, 540, 670],
                                    metadata=metadata)
 
     # Output to geotif if requested


### PR DESCRIPTION
**Describe your changes**
Changes red channel default value from 650 in `read.geotif` and 630 in `read.netcdf` to 670 across the board.

**Type of update**
This is a feature enhancement (making gcv work better with expected camera types)

**Associated issues**
Closes #137 

**Additional context**
None

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv-geospatial/mkdocs.yml`
- [x] Changes to function input/output signatures added to `changelog.md`
- [x] Code reviewed
- [x] PR approved
