### PR TITLE
Fix hardcoded nodata value in analyze.color by using GEO object internal nodata

### DIFF
--- a/plantcv/geospatial/analyze/color.py
+++ b/plantcv/geospatial/analyze/color.py
@@ -61,10 +61,10 @@ def _channel_stats(img, mask, geojson, bins, channels, channel_ids, histrange, i
     for idx, channel in enumerate(channels):
         # Convert to float and fill in no data values required for zonal stats
         channel = channel.astype(np.float32)
-        channel[mask == 0] = -999
+        channel[mask == 0] = img.nodata
         color_values = zonal_stats(geojson, channel,
                                    affine=img.transform,
-                                   nodata=-999, stats=['mean', 'std'],
+                                   nodata=img.nodata, stats=['mean', 'std'],
                                    add_stats={'histogram': lambda x: _histogram_stats(x, bins=bins, histrange=histrange)})
         for i, id in enumerate(ids):
             j = color_values[i]
@@ -123,14 +123,14 @@ def color(img, bin_mask, geojson, bins=10, colorspaces="hsv", label=None):
     h, s, v = cv2.split(hsv)
 
     h = h.astype(np.float32)
-    h[bin_mask == 0] = -999
+    h[bin_mask == 0] = img.nodata
 
     ids = _gather_ids(geojson=geojson)
 
     hcm = []
     hue_stats = zonal_stats(geojson, h,
                             affine=img.transform,
-                            nodata=-999, stats=['mean'],
+                            nodata=img.nodata, stats=['mean'],
                             add_stats={'hue_stats': partial(_hue_circ_stats)})
 
     for idx, i in enumerate(hue_stats):

--- a/plantcv/geospatial/analyze/color.py
+++ b/plantcv/geospatial/analyze/color.py
@@ -60,11 +60,15 @@ def _channel_stats(img, mask, geojson, bins, channels, channel_ids, histrange, i
     """
     for idx, channel in enumerate(channels):
         # Convert to float and fill in no data values required for zonal stats
+        nodata_val = getattr(img, 'nodata', None)
+        if nodata_val is None:
+            nodata_val = -999
+
         channel = channel.astype(np.float32)
-        channel[mask == 0] = img.nodata
+        channel[mask == 0] = nodata_val
         color_values = zonal_stats(geojson, channel,
                                    affine=img.transform,
-                                   nodata=img.nodata, stats=['mean', 'std'],
+                                   nodata=nodata_val, stats=['mean', 'std'],
                                    add_stats={'histogram': lambda x: _histogram_stats(x, bins=bins, histrange=histrange)})
         for i, id in enumerate(ids):
             j = color_values[i]
@@ -123,14 +127,19 @@ def color(img, bin_mask, geojson, bins=10, colorspaces="hsv", label=None):
     h, s, v = cv2.split(hsv)
 
     h = h.astype(np.float32)
-    h[bin_mask == 0] = img.nodata
+
+    nodata_val = getattr(img, 'nodata', None)
+    if nodata_val is None:
+        nodata_val = -999
+
+    h[bin_mask == 0] = nodata_val
 
     ids = _gather_ids(geojson=geojson)
 
     hcm = []
     hue_stats = zonal_stats(geojson, h,
                             affine=img.transform,
-                            nodata=img.nodata, stats=['mean'],
+                            nodata=nodata_val, stats=['mean'],
                             add_stats={'hue_stats': partial(_hue_circ_stats)})
 
     for idx, i in enumerate(hue_stats):


### PR DESCRIPTION
**Describe your changes**
This PR fixes a bug where the `nodata` value in `analyze.color` was hardcoded to `-999`. 
* **Previous functionality:** When masking images and running raster stats (`zonal_stats`), the functions `_channel_stats` and `color` used a hardcoded `-999` for the nodata value. 
* **New functionality:** The code now dynamically references `img.nodata` from the passed `GEO` object for both image masking and the `zonal_stats` nodata parameter. This ensures the correct, image-specific nodata value is always used.

**Type of update**
* Bug fix

**Associated issues**
Closes https://github.com/danforthcenter/plantcv-geospatial/issues/151

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv-geospatial/mkdocs.yml`
- [x] Changes to function input/output signatures added to `changelog.md`
- [x] Code reviewed
- [x] PR approved
