### PR TITLE
Update documentation to include label parameter

### DIFF
--- a/docs/analyze_color.md
+++ b/docs/analyze_color.md
@@ -10,6 +10,7 @@ Vectorized approach to color stats and histograms per region in a shapefile usin
     - img - GEO image object, likely read in with [`gcv.read_geotif`](read_geotif.md)
     - bin_mask - Binary mask, numpy array
     - geojson - Path to the shapefile/GeoJSON containing the plot boundaries. Can be Polygon or MultiPolygon geometry.
+    - label - Optional label parameter, modifies the variable name of observations recorded. Can be a prefix, or list (default = `pcv.params.sample_label`)
 
 - **Context:** 
     - **Output data stored:** Data ('mean', 'std', 'counts', 'bin_edges') for each specified channel and ('hue_circular_mean', 'hue_circular_std') for each plot automatically gets stored to the [`Outputs` class](https://plantcv.readthedocs.io/en/stable/outputs/#class-outputs) when this function is run. These data can be accessed during a workflow (example below). For more detail about data output see [Summary of Output Observations](https://plantcv.readthedocs.io/en/stable/output_measurements/).

--- a/docs/analyze_coverage.md
+++ b/docs/analyze_coverage.md
@@ -2,7 +2,7 @@
 
 Vectorize approach to pixel count and percent coverage per region in a shapefile using a binary mask. 
 
-**plantcv.geospatial.analyze.coverage**(*img, bin_mask, geojson*)
+**plantcv.geospatial.analyze.coverage**(*img, bin_mask, geojson, label=None*)
 
 **returns** Debug image with regions drawn on the input image.
 
@@ -10,6 +10,7 @@ Vectorize approach to pixel count and percent coverage per region in a shapefile
     - img - GEO image object, likely read in with [`gcv.read_geotif`](read_geotif.md)
     - bin_mask - Binary mask, numpy array
     - geojson - Path to the shapefile/GeoJSON containing the plot boundaries. Can be Polygon or MultiPolygon geometry.
+    - label - Optional label parameter, modifies the variable name of observations recorded. Can be a prefix, or list (default = `pcv.params.sample_label`)
 
 - **Context:**
     - This function will utilize the geojson's `ID` attribute for `Outputs` labels if available. 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented below.
 
 #### geospatial.analyze.coverage
 
-* v0.1dev: **geospatial.analyze.coverage**(*img, bin_mask, geojson*)
+* v0.1dev: **geospatial.analyze.coverage**(*img, bin_mask, geojson, label=None*)
 
 #### geospatial.analyze.height_percentile
 


### PR DESCRIPTION
**Describe your changes**
The documentation for `analyze.coverage` did not include the optional label parameter, leading to an issue suggesting that it didn't have the option to take a label input. Just a docs problem after all, but this PR fixes it. 

**Type of update**
* Update to documentation

**Associated issues**
Closes #157 

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv-geospatial/mkdocs.yml`
- [x] Changes to function input/output signatures added to `changelog.md`
- [x] Code reviewed
- [x] PR approved
