### PR TITLE
fix band order in napari

### DIFF
--- a/plantcv/geospatial/create_shapes/interactive_shapes.py
+++ b/plantcv/geospatial/create_shapes/interactive_shapes.py
@@ -1,6 +1,7 @@
 # PlantCV-Geospatial classes
 
 import napari
+import numpy as np
 from plantcv.plantcv import fatal_error
 from plantcv.geospatial.create_shapes.napari_grid import _napari_grid
 from plantcv.geospatial.create_shapes.napari_polygon_grid import _napari_polygon_grid
@@ -32,7 +33,8 @@ class InteractiveShapes:
 
         self.img = img
         self.layer_dict = {}
-        self.viewer.add_image(self.img.thumb)
+        # Change band order because napari expects RGB
+        self.viewer.add_image(np.flip(self.img.thumb, axis=-1))
         self.viewer.add_shapes(name=field_layer)
         self.layer_dict["field_boundary"] = field_layer
 


### PR DESCRIPTION
**Describe your changes**
This issue was identified some time ago and I thought we'd fixed it, but it must've gotten changed back along the way. Napari expects RGB and since we store in BGR, this flips the band order of the thumbnail so that it displays correctly.

**Type of update**
* Bug fix

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv-geospatial/mkdocs.yml`
- [x] Changes to function input/output signatures added to `changelog.md`
- [x] Code reviewed
- [x] PR approved
